### PR TITLE
Autogen fixes

### DIFF
--- a/tools/generators/vehicle_models/Program.cs
+++ b/tools/generators/vehicle_models/Program.cs
@@ -168,7 +168,7 @@ namespace VehiclePageCreator
 
             foreach (var vehicle in sortedVehiclesByName)
             {
-                gallery.WriteLine($"  {vehicle.Name.ToLower()} = {vehicle.HexHash};");
+                gallery.WriteLine($"  {vehicle.Name.ToLower()} = {vehicle.HexHash},");
             }
 
             gallery.WriteLine("}");

--- a/tools/generators/weapon_models/Program.cs
+++ b/tools/generators/weapon_models/Program.cs
@@ -155,7 +155,7 @@ namespace WeaponPageCreator
 
             foreach (var weapon in filteredWeapons)
             {
-                gallery.WriteLine($"  {weapon.Name.ToLower()} = {weapon.Hash.ToString("X").Insert(0, "0x")};");
+                gallery.WriteLine($"  {weapon.Name.ToLower()} = {weapon.Hash.ToString("X").Insert(0, "0x")},");
             }
 
             gallery.WriteLine("}");


### PR DESCRIPTION
Related to PR #41 
Changed auto gen to use `,` instead `;` for ts enums